### PR TITLE
Added new migration for relationships table, which will contain all u…

### DIFF
--- a/data/migrations/20191007185816_create_relationships.js
+++ b/data/migrations/20191007185816_create_relationships.js
@@ -1,0 +1,22 @@
+exports.up = function(knex) {
+  return knex.schema.createTable("relationships", relationships => {
+    relationships.increments();
+    relationships
+      .string("user_id", 128)
+      .references("users.uid")
+      .notNullable()
+      .onDelete("CASCADE")
+      .onUpdate("CASCADE");
+    relationships
+      .string("mediator_id", 128)
+      .references("users.id")
+      .notNullable()
+      .onDelete("CASCADE")
+      .onUpdate("CASCADE");
+    relationships.timestamps(true, true);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTableIfExists("relationships");
+};


### PR DESCRIPTION
…ser-mediator relationships for use in the front-end in app messaging.

# Description

- Added a new migration for the relationships table. Each row in this table will reference two users, a regular user and a mediator. The purpose of this relationships table is so that a logged in user may access a list of mediators they have cases with on the front-end when using the in-app messaging. Every mediator a user has had a case with will have a "relationship" with them in this table, and will be message-able.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
